### PR TITLE
Fix `KeyError` in `should_log` during sync on a server with threads

### DIFF
--- a/activitylog/activitylog.py
+++ b/activitylog/activitylog.py
@@ -1,4 +1,5 @@
 # redbot/discord
+from itertools import chain
 from tokenize import String
 from discord.user import User
 from discord.member import Member
@@ -195,7 +196,7 @@ class ActivityLogger(commands.Cog):
 
         guilds = self.bot.guilds
         for guild in guilds:
-            for channel in guild.channels:
+            for channel in chain(guild.channels, guild.threads):
                 if not channel.id in self.cache.keys():
                     self.cache[channel.id] = self.default_channel.copy()
 

--- a/activitylog/activitylog.py
+++ b/activitylog/activitylog.py
@@ -278,11 +278,7 @@ class ActivityLogger(commands.Cog):
 
         elif type(location) is discord.TextChannel or type(location) is discord.Thread:
             loc = self.cache[location.guild.id]
-            opts = [
-                loc.get("all_s", False),
-                self.cache[location.id].get("enabled", default),
-            ]
-            return any(opts)
+            return loc.get("all_s", False) or self.cache.get(location.id, {}).get("enabled", default)
 
         elif type(location) is discord.VoiceChannel:
             loc = self.cache[location.guild.id]


### PR DESCRIPTION
This change fixes a `KeyError` when running `logset sync` in a guild which has been set up using `logset server on`.

The current error is as follows:

```
Exception in command 'logset sync'
Traceback (most recent call last):
  File "/data/venv/lib/python3.11/site-packages/discord/ext/commands/core.py", line 235, in wrapped
    ret = await coro(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/cogs/CogManager/cogs/activitylog/activitylog.py", line 858, in sync_guild
    await sync_channel(thread)
  File "/data/cogs/CogManager/cogs/activitylog/activitylog.py", line 832, in sync_channel
    if not (self.should_log(channel) or self.should_log(channel.guild)):
            ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/cogs/CogManager/cogs/activitylog/activitylog.py", line 283, in should_log
    self.cache[location.id].get("enabled", default),
    ~~~~~~~~~~^^^^^^^^^^^^^
KeyError: 1380258400398475374

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/data/venv/lib/python3.11/site-packages/discord/ext/commands/bot.py", line 1366, in invoke
    await ctx.command.invoke(ctx)
  File "/data/venv/lib/python3.11/site-packages/redbot/core/commands/commands.py", line 825, in invoke
    await super().invoke(ctx)
  File "/data/venv/lib/python3.11/site-packages/discord/ext/commands/core.py", line 1650, in invoke
    await ctx.invoked_subcommand.invoke(ctx)
  File "/data/venv/lib/python3.11/site-packages/discord/ext/commands/core.py", line 1029, in invoke
    await injected(*ctx.args, **ctx.kwargs)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/venv/lib/python3.11/site-packages/discord/ext/commands/core.py", line 244, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: KeyError: 1380258400398475374
```

and comes about due to the threads not being added to the cache, and the "server on" check in `should_log` not superseding the check of the cache for the thread - the cache check happens regardless of whether the entire server is set to "on".

I've fixed both of these issues to make the cog more reliable.