### PR TITLE
serverwatch: fix threshold alerts re-pinging on map changes

### DIFF
--- a/serverwatch/serverwatch.py
+++ b/serverwatch/serverwatch.py
@@ -43,7 +43,7 @@ class ServerWatch(commands.Cog):
         default_guild = {
             "servers": {},  # name.lower() -> server dict
             "poll_interval": 60,
-            "cooldown": 1800,
+            "rearm_grace": 120,  # seconds below a threshold before its alert re-arms
             "rename_interval": 360,
         }
         self.config.register_guild(**default_guild)
@@ -175,7 +175,7 @@ class ServerWatch(commands.Cog):
             cached = self._cache.get((guild.id, key))
             cur = cached["info"].player_count if cached and cached.get("info") is not None else None
             armed = not (cur is not None and cur >= count)
-            s["ping_state"][str(rule_id)] = {"armed": armed, "last_ping": 0.0}
+            s["ping_state"][str(rule_id)] = {"armed": armed, "below_since": None}
         return rule_id
 
     async def _remove_threshold(self, guild, name, rule_id):
@@ -249,7 +249,7 @@ class ServerWatch(commands.Cog):
             seconds = max(MIN_POLL, seconds)
         elif key == "rename_interval":
             seconds = max(MIN_RENAME, seconds)
-        elif key == "cooldown":
+        elif key == "rearm_grace":
             seconds = max(0, seconds)
         else:
             raise ServerWatchError("Unknown interval setting.")
@@ -404,7 +404,7 @@ class ServerWatch(commands.Cog):
                 self._last_poll[guild.id] = now
 
                 rename_interval = max(MIN_RENAME, await gconf.rename_interval())
-                cooldown = await gconf.cooldown()
+                rearm_grace = await gconf.rearm_grace()
                 servers = await gconf.servers()
 
                 for key in list(servers.keys()):
@@ -415,7 +415,7 @@ class ServerWatch(commands.Cog):
                     # Fast: refresh the live status message/embed
                     await self._update_status_message(guild, key, s, info)
                     # Fast: evaluate thresholds (reads/writes live config inside)
-                    await self._evaluate_thresholds(guild, key, info, cooldown)
+                    await self._evaluate_thresholds(guild, key, info, rearm_grace)
                     # Slow: channel rename, gated by elapsed time per server
                     if (now - self._last_rename.get((guild.id, key), 0)) >= rename_interval:
                         await self._update_channel_name(guild, key, s, info)
@@ -454,7 +454,7 @@ class ServerWatch(commands.Cog):
         except discord.HTTPException:
             return
 
-    async def _evaluate_thresholds(self, guild, key, info, cooldown):
+    async def _evaluate_thresholds(self, guild, key, info, rearm_grace):
         async with self.config.guild(guild).servers() as servers:
             s = servers.get(key)
             if not s:
@@ -479,15 +479,26 @@ class ServerWatch(commands.Cog):
 
             for rule in s["thresholds"]:
                 rid = str(rule["id"])
-                st = state.setdefault(rid, {"armed": True, "last_ping": 0.0})
+                st = state.setdefault(rid, {"armed": True, "below_since": None})
                 threshold = rule["count"]
 
                 if current < threshold:
-                    st["armed"] = True
+                    # Re-arm only after the count has stayed below the threshold for
+                    # `rearm_grace` seconds. A brief dip (e.g. a TF2 map change empties the
+                    # server for a few seconds while players reconnect) must NOT reset the
+                    # alert, or it would ping again every time the map rotates.
+                    if st.get("below_since") is None:
+                        st["below_since"] = now
+                    if not st.get("armed", True) and (now - st["below_since"]) >= rearm_grace:
+                        st["armed"] = True
                     continue
 
-                # current >= threshold
-                if st["armed"] and (now - st.get("last_ping", 0.0)) >= cooldown:
+                # current >= threshold: it's back up, so cancel any pending re-arm.
+                st["below_since"] = None
+
+                # Edge-triggered: fire once on the upward crossing, then stay silent until
+                # the rule re-arms (a sustained drop back under the threshold).
+                if st.get("armed", True):
                     role = guild.get_role(rule["role_id"])
                     if notify_channel and role:
                         msg = self._format_template(
@@ -501,7 +512,6 @@ class ServerWatch(commands.Cog):
                                 ),
                             )
                             st["armed"] = False
-                            st["last_ping"] = now
                         except discord.HTTPException:
                             pass  # missing perms / deleted channel — retry next poll
 
@@ -888,11 +898,17 @@ class ServerWatch(commands.Cog):
         value = await self._set_interval(ctx.guild, "poll_interval", seconds)
         await ctx.send(info(f"Poll interval set to **{value}s**."))
 
-    @sw_set.command(name="cooldown")
-    async def sw_set_cooldown(self, ctx, seconds: int):
-        """Set the minimum time before a threshold rule may ping again."""
-        value = await self._set_interval(ctx.guild, "cooldown", seconds)
-        await ctx.send(info(f"Re-ping cooldown set to **{value}s**."))
+    @sw_set.command(name="rearmgrace", aliases=["rearm"])
+    async def sw_set_rearmgrace(self, ctx, seconds: int):
+        """
+        Set how long a server must stay BELOW a threshold before that alert re-arms.
+
+        A rule pings once when the player count crosses its threshold, then goes silent.
+        It will only ping again after the count drops back under the threshold for this
+        long — which stops brief dips (like TF2 map changes) from causing repeat pings.
+        """
+        value = await self._set_interval(ctx.guild, "rearm_grace", seconds)
+        await ctx.send(info(f"Re-arm grace set to **{value}s** (a sustained drop below a threshold re-arms its alert)."))
 
     @sw_set.command(name="renameinterval")
     async def sw_set_renameinterval(self, ctx, seconds: int):

--- a/serverwatch/views.py
+++ b/serverwatch/views.py
@@ -156,28 +156,30 @@ class TemplateModal(discord.ui.Modal, title="Channel-name Template"):
 
 
 class IntervalsModal(discord.ui.Modal, title="Timing Settings"):
-    def __init__(self, panel, poll, cooldown, rename):
+    def __init__(self, panel, poll, rearm_grace, rename):
         super().__init__()
         self.panel = panel
         self.poll = discord.ui.TextInput(label="Poll interval (s, min 30)", default=str(poll), required=True, max_length=6)
-        self.cooldown = discord.ui.TextInput(label="Re-ping cooldown (s)", default=str(cooldown), required=True, max_length=7)
+        self.rearm = discord.ui.TextInput(
+            label="Re-arm grace (s below threshold)", default=str(rearm_grace), required=True, max_length=7
+        )
         self.rename = discord.ui.TextInput(
             label="Channel rename interval (s, min 300)", default=str(rename), required=True, max_length=6
         )
         self.add_item(self.poll)
-        self.add_item(self.cooldown)
+        self.add_item(self.rearm)
         self.add_item(self.rename)
 
     async def on_submit(self, interaction):
         try:
             poll = int(self.poll.value.strip())
-            cd = int(self.cooldown.value.strip())
+            rg = int(self.rearm.value.strip())
             rn = int(self.rename.value.strip())
         except ValueError:
             await interaction.response.send_message("All values must be whole numbers (seconds).", ephemeral=True)
             return
         await self.panel.cog._set_interval(self.panel.guild, "poll_interval", poll)
-        await self.panel.cog._set_interval(self.panel.guild, "cooldown", cd)
+        await self.panel.cog._set_interval(self.panel.guild, "rearm_grace", rg)
         await self.panel.cog._set_interval(self.panel.guild, "rename_interval", rn)
         self.panel._notice = "✅ Timing settings updated."
         await self.panel._show(interaction)
@@ -619,9 +621,9 @@ class ServerWatchPanel(discord.ui.View):
         async def cb(interaction):
             gconf = self.cog.config.guild(self.guild)
             poll = await gconf.poll_interval()
-            cd = await gconf.cooldown()
+            rg = await gconf.rearm_grace()
             rn = await gconf.rename_interval()
-            await interaction.response.send_modal(IntervalsModal(self, poll, cd, rn))
+            await interaction.response.send_modal(IntervalsModal(self, poll, rg, rn))
 
         edit.callback = cb
         self.add_item(edit)
@@ -725,13 +727,13 @@ class ServerWatchPanel(discord.ui.View):
     async def _add_intervals_field(self, embed):
         gconf = self.cog.config.guild(self.guild)
         poll = await gconf.poll_interval()
-        cd = await gconf.cooldown()
+        rg = await gconf.rearm_grace()
         rn = await gconf.rename_interval()
         embed.add_field(
             name="Timing (guild-wide)",
             value=(
                 f"Poll interval: **{poll}s**\n"
-                f"Re-ping cooldown: **{cd}s**\n"
+                f"Re-arm grace: **{rg}s** (sustained drop below a threshold before it re-arms)\n"
                 f"Channel-rename interval: **{rn}s**"
             ),
             inline=False,


### PR DESCRIPTION
Threshold rules re-armed the instant player_count dropped below the threshold for a single poll. TF2 map rotations briefly empty the server while players reconnect, so every map change re-armed the alert and it re-fired on refill (a ping ~every cooldown window).

Replace the per-fire cooldown with edge-triggered firing plus a sustained-drop re-arm: a rule fires once on the upward crossing, then only re-arms after the count stays below the threshold for `rearm_grace` seconds (tracked via a per-rule `below_since` timer that resets the moment the count climbs back). Brief dips no longer reset the alert.

- Guild `cooldown` setting -> `rearm_grace` (default 120s); command `serverwatch set rearmgrace` (alias `rearm`), panel Intervals modal, and Intervals view updated accordingly.
- ping_state migrates lazily (below_since defaulted via .get); rules already disarmed stay quiet on reload.