### PR TITLE
serverwatch: cap threshold spam with both re-arm grace and cooldown

### DIFF
--- a/serverwatch/serverwatch.py
+++ b/serverwatch/serverwatch.py
@@ -44,6 +44,7 @@ class ServerWatch(commands.Cog):
             "servers": {},  # name.lower() -> server dict
             "poll_interval": 60,
             "rearm_grace": 120,  # seconds below a threshold before its alert re-arms
+            "cooldown": 1800,  # minimum seconds between pings of the same rule
             "rename_interval": 360,
         }
         self.config.register_guild(**default_guild)
@@ -170,12 +171,12 @@ class ServerWatch(commands.Cog):
                     "message": message or DEFAULT_THRESHOLD_MESSAGE,
                 }
             )
-            # Prime arm state: if the server is already at/above this count, start disarmed
-            # so an already-full server does not ping until it drains and refills.
+            # Disarm if already at/above the count, so an already-full server doesn't
+            # ping until it drains and refills.
             cached = self._cache.get((guild.id, key))
             cur = cached["info"].player_count if cached and cached.get("info") is not None else None
             armed = not (cur is not None and cur >= count)
-            s["ping_state"][str(rule_id)] = {"armed": armed, "below_since": None}
+            s["ping_state"][str(rule_id)] = {"armed": armed, "below_since": None, "last_ping": 0.0}
         return rule_id
 
     async def _remove_threshold(self, guild, name, rule_id):
@@ -249,7 +250,7 @@ class ServerWatch(commands.Cog):
             seconds = max(MIN_POLL, seconds)
         elif key == "rename_interval":
             seconds = max(MIN_RENAME, seconds)
-        elif key == "rearm_grace":
+        elif key in ("rearm_grace", "cooldown"):
             seconds = max(0, seconds)
         else:
             raise ServerWatchError("Unknown interval setting.")
@@ -274,8 +275,7 @@ class ServerWatch(commands.Cog):
         port = server.get("port")
         if not host or not port:
             return None
-        # ainfo raises asyncio.TimeoutError / a2s.BrokenMessageError / OSError for unreachable
-        # servers; treat any failure as "offline" so the loop never dies on a bad host.
+        # Any failure (timeout, bad host, protocol error) means the server is offline.
         try:
             return await a2s.ainfo((host, int(port)), timeout=QUERY_TIMEOUT)
         except Exception:
@@ -405,6 +405,7 @@ class ServerWatch(commands.Cog):
 
                 rename_interval = max(MIN_RENAME, await gconf.rename_interval())
                 rearm_grace = await gconf.rearm_grace()
+                cooldown = await gconf.cooldown()
                 servers = await gconf.servers()
 
                 for key in list(servers.keys()):
@@ -415,12 +416,11 @@ class ServerWatch(commands.Cog):
                     # Fast: refresh the live status message/embed
                     await self._update_status_message(guild, key, s, info)
                     # Fast: evaluate thresholds (reads/writes live config inside)
-                    await self._evaluate_thresholds(guild, key, info, rearm_grace)
+                    await self._evaluate_thresholds(guild, key, info, rearm_grace, cooldown)
                     # Slow: channel rename, gated by elapsed time per server
                     if (now - self._last_rename.get((guild.id, key), 0)) >= rename_interval:
                         await self._update_channel_name(guild, key, s, info)
-                        # Record the attempt regardless of outcome so a 429 / no-op
-                        # backs off a full interval instead of hammering.
+                        # Record the attempt either way so a 429/no-op backs off a full interval.
                         self._last_rename[(guild.id, key)] = now
 
             await asyncio.sleep(BASE_TICK)
@@ -454,7 +454,7 @@ class ServerWatch(commands.Cog):
         except discord.HTTPException:
             return
 
-    async def _evaluate_thresholds(self, guild, key, info, rearm_grace):
+    async def _evaluate_thresholds(self, guild, key, info, rearm_grace, cooldown):
         async with self.config.guild(guild).servers() as servers:
             s = servers.get(key)
             if not s:
@@ -479,26 +479,24 @@ class ServerWatch(commands.Cog):
 
             for rule in s["thresholds"]:
                 rid = str(rule["id"])
-                st = state.setdefault(rid, {"armed": True, "below_since": None})
+                st = state.setdefault(rid, {"armed": True, "below_since": None, "last_ping": 0.0})
                 threshold = rule["count"]
 
                 if current < threshold:
-                    # Re-arm only after the count has stayed below the threshold for
-                    # `rearm_grace` seconds. A brief dip (e.g. a TF2 map change empties the
-                    # server for a few seconds while players reconnect) must NOT reset the
-                    # alert, or it would ping again every time the map rotates.
+                    # Re-arm only after a sustained drop (>= rearm_grace), so a brief dip
+                    # like a map change doesn't reset the alert and cause a repeat ping.
                     if st.get("below_since") is None:
                         st["below_since"] = now
                     if not st.get("armed", True) and (now - st["below_since"]) >= rearm_grace:
                         st["armed"] = True
                     continue
 
-                # current >= threshold: it's back up, so cancel any pending re-arm.
+                # back above the threshold — cancel any pending re-arm
                 st["below_since"] = None
 
-                # Edge-triggered: fire once on the upward crossing, then stay silent until
-                # the rule re-arms (a sustained drop back under the threshold).
-                if st.get("armed", True):
+                # Fire once per crossing (gated by `armed`), and at most once per `cooldown`
+                # so a population hovering around the threshold can't spam.
+                if st.get("armed", True) and (now - st.get("last_ping", 0.0)) >= cooldown:
                     role = guild.get_role(rule["role_id"])
                     if notify_channel and role:
                         msg = self._format_template(
@@ -512,6 +510,7 @@ class ServerWatch(commands.Cog):
                                 ),
                             )
                             st["armed"] = False
+                            st["last_ping"] = now
                         except discord.HTTPException:
                             pass  # missing perms / deleted channel — retry next poll
 
@@ -909,6 +908,17 @@ class ServerWatch(commands.Cog):
         """
         value = await self._set_interval(ctx.guild, "rearm_grace", seconds)
         await ctx.send(info(f"Re-arm grace set to **{value}s** (a sustained drop below a threshold re-arms its alert)."))
+
+    @sw_set.command(name="cooldown")
+    async def sw_set_cooldown(self, ctx, seconds: int):
+        """
+        Set the minimum time between pings of the same threshold rule.
+
+        Even after a rule re-arms, it won't ping again until this long has passed since its
+        last ping. Stops a population hovering around a threshold from spamming.
+        """
+        value = await self._set_interval(ctx.guild, "cooldown", seconds)
+        await ctx.send(info(f"Re-ping cooldown set to **{value}s** (minimum time between pings of the same rule)."))
 
     @sw_set.command(name="renameinterval")
     async def sw_set_renameinterval(self, ctx, seconds: int):

--- a/serverwatch/views.py
+++ b/serverwatch/views.py
@@ -156,30 +156,36 @@ class TemplateModal(discord.ui.Modal, title="Channel-name Template"):
 
 
 class IntervalsModal(discord.ui.Modal, title="Timing Settings"):
-    def __init__(self, panel, poll, rearm_grace, rename):
+    def __init__(self, panel, poll, rearm_grace, cooldown, rename):
         super().__init__()
         self.panel = panel
         self.poll = discord.ui.TextInput(label="Poll interval (s, min 30)", default=str(poll), required=True, max_length=6)
         self.rearm = discord.ui.TextInput(
             label="Re-arm grace (s below threshold)", default=str(rearm_grace), required=True, max_length=7
         )
+        self.cooldown = discord.ui.TextInput(
+            label="Re-ping cooldown (s between pings)", default=str(cooldown), required=True, max_length=7
+        )
         self.rename = discord.ui.TextInput(
             label="Channel rename interval (s, min 300)", default=str(rename), required=True, max_length=6
         )
         self.add_item(self.poll)
         self.add_item(self.rearm)
+        self.add_item(self.cooldown)
         self.add_item(self.rename)
 
     async def on_submit(self, interaction):
         try:
             poll = int(self.poll.value.strip())
             rg = int(self.rearm.value.strip())
+            cd = int(self.cooldown.value.strip())
             rn = int(self.rename.value.strip())
         except ValueError:
             await interaction.response.send_message("All values must be whole numbers (seconds).", ephemeral=True)
             return
         await self.panel.cog._set_interval(self.panel.guild, "poll_interval", poll)
         await self.panel.cog._set_interval(self.panel.guild, "rearm_grace", rg)
+        await self.panel.cog._set_interval(self.panel.guild, "cooldown", cd)
         await self.panel.cog._set_interval(self.panel.guild, "rename_interval", rn)
         self.panel._notice = "✅ Timing settings updated."
         await self.panel._show(interaction)
@@ -622,8 +628,9 @@ class ServerWatchPanel(discord.ui.View):
             gconf = self.cog.config.guild(self.guild)
             poll = await gconf.poll_interval()
             rg = await gconf.rearm_grace()
+            cd = await gconf.cooldown()
             rn = await gconf.rename_interval()
-            await interaction.response.send_modal(IntervalsModal(self, poll, rg, rn))
+            await interaction.response.send_modal(IntervalsModal(self, poll, rg, cd, rn))
 
         edit.callback = cb
         self.add_item(edit)
@@ -728,12 +735,14 @@ class ServerWatchPanel(discord.ui.View):
         gconf = self.cog.config.guild(self.guild)
         poll = await gconf.poll_interval()
         rg = await gconf.rearm_grace()
+        cd = await gconf.cooldown()
         rn = await gconf.rename_interval()
         embed.add_field(
             name="Timing (guild-wide)",
             value=(
                 f"Poll interval: **{poll}s**\n"
                 f"Re-arm grace: **{rg}s** (sustained drop below a threshold before it re-arms)\n"
+                f"Re-ping cooldown: **{cd}s** (minimum time between pings of a rule)\n"
                 f"Channel-rename interval: **{rn}s**"
             ),
             inline=False,


### PR DESCRIPTION
The sustained-drop re-arm alone still lets a population hovering around a threshold re-ping: genuine dips below the threshold (longer than rearm_grace) re-arm the rule, so each re-crossing fires.

Re-add the per-rule cooldown gate alongside the re-arm logic. A rule now fires once per upward crossing AND at most once per `cooldown` since its last ping. rearm_grace kills transient map-change re-pings; cooldown caps genuine hovering.

- Restore guild `cooldown` setting (default 1800s) and `set cooldown`; the Intervals modal/view show both rearm_grace and cooldown.
- ping_state tracks `last_ping` again (lazily defaulted via .get).
- Tighten over-explained comments in the threshold/query logic.