### PR TITLE
pony - solve derpibooru's challenge and back off instead of failing

### DIFF
--- a/pony/derpi.py
+++ b/pony/derpi.py
@@ -1,0 +1,226 @@
+"""
+Derpibooru API access: challenge solving and backoff.
+
+Derpibooru answers 501 with an html interstitial while it is shedding load, and 500
+with an empty body once an IP is blocked. The interstitial is its own, not
+Cloudflare's: a form with two hidden fields and a submit button, no javascript. The
+clearance it grants is keyed to our IP and sets no cookie, so every guild shares it.
+
+Requests sent during a block restart its 15 minute timer, so a fetch spends at most
+three requests (GET, POST /challenge, GET) and solves at most once. A retry that is
+challenged again gives up rather than solving in a loop.
+
+No discord or redbot imports here; the gate and the parser are tested standalone.
+"""
+
+import asyncio
+import html
+import random
+import re
+import ssl
+import time
+from collections import deque
+from typing import Dict, Optional, Tuple
+
+import aiohttp
+
+__all__ = [
+    "CHALLENGE_URL",
+    "ChallengeGate",
+    "DerpiBusy",
+    "DerpiCold",
+    "DerpiError",
+    "fetch_json",
+    "make_ssl_context",
+    "parse_challenge",
+]
+
+CHALLENGE_URL = "https://derpibooru.org/challenge"
+
+# Derpibooru wants 5s after a 501 before the endpoint is hit again. Submitting
+# /challenge is the interstitial's own form and doesn't count; the retry does.
+SOLVE_RETRY_WAIT = 5.0
+
+# Don't come back the instant a block expires.
+_BLOCK_JITTER = 60.0
+
+_INPUT_RE = re.compile(r"<input\b[^>]*>", re.I)
+_ATTR_RE = re.compile(r'([\w-]+)\s*=\s*"([^"]*)"')
+
+
+def make_ssl_context() -> ssl.SSLContext:
+    """TLS settings that get past the Cloudflare layer in front of Derpibooru.
+
+    Cloudflare fingerprints the ClientHello (JA3/JA4). aiohttp's default omits the
+    ALPN and post_handshake_auth extensions and draws a 403 whatever the User-Agent;
+    python's own http.client sends both and passes.
+    """
+    ctx = ssl.create_default_context()
+    ctx.set_alpn_protocols(["http/1.1"])
+    ctx.post_handshake_auth = True
+    return ctx
+
+
+class DerpiError(Exception):
+    """Derpibooru could not be reached or answered with something unusable."""
+
+
+class DerpiBusy(DerpiError):
+    """Challenged or briefly unavailable. Retrying shortly is reasonable."""
+
+
+class DerpiCold(DerpiError):
+    """Backing off; no request may be sent."""
+
+    def __init__(self, remaining: float):
+        super().__init__("backing off for {:.0f}s".format(remaining))
+        self.remaining = remaining
+
+
+def parse_challenge(body: str) -> Optional[Dict[str, str]]:
+    """Pull the hidden fields out of the interstitial form.
+
+    Returns None when the page is not the form we know, so the caller backs off
+    instead of POSTing a guess at /challenge.
+    """
+    fields: Dict[str, str] = {}
+    for tag in _INPUT_RE.findall(body):
+        # Attribute names are case insensitive in html; values are not.
+        attrs = {k.lower(): v for k, v in _ATTR_RE.findall(tag)}
+        name = attrs.get("name")
+        if name in ("_key", "referer"):
+            fields[name] = html.unescape(attrs.get("value", ""))
+
+    if not fields.get("_key"):
+        return None
+    # Only steers the 302, which we don't follow, so a missing one is harmless.
+    fields.setdefault("referer", "/")
+    return fields
+
+
+class ChallengeGate:
+    """Backoff state for Derpibooru, shared by the whole cog.
+
+    A 501 is routine, since the site challenges on its own load rather than on
+    anything we did, so it is solved and counted and only a run of them trips the
+    breaker. A 500 means we are already blocked and goes cold at once.
+
+    Tuning is passed per call rather than stored, so a [p]ponyset change lands on
+    the next request.
+    """
+
+    def __init__(self, maxlen: int = 64):
+        self._challenges: deque = deque(maxlen=maxlen)
+        self._blocked_until: float = 0.0
+
+    @property
+    def blocked_until(self) -> float:
+        return self._blocked_until
+
+    def restore(self, blocked_until: float) -> None:
+        """Reload a cold period that outlived a cog reload."""
+        self._blocked_until = max(self._blocked_until, blocked_until)
+
+    def cold_remaining(self, now: float) -> float:
+        return max(0.0, self._blocked_until - now)
+
+    def challenges_in_window(self, now: float, window: float) -> int:
+        self._prune(now, window)
+        return len(self._challenges)
+
+    def record_challenge(self, now: float, *, threshold: int, window: float, cooldown: float) -> bool:
+        """Count one challenged invocation. True if that tripped the breaker.
+
+        Call at most once per invocation; counting the initial 501 and the one after
+        a failed solve would halve the effective threshold.
+        """
+        self._challenges.append(now)
+        self._prune(now, window)
+        if len(self._challenges) > threshold:
+            self._blocked_until = max(self._blocked_until, now + cooldown)
+            return True
+        return False
+
+    def record_block(self, now: float, *, cooldown: float) -> None:
+        """A 500: we are hard-blocked. Only ever lengthens the cold period."""
+        self._blocked_until = max(self._blocked_until, now + cooldown + random.uniform(0, _BLOCK_JITTER))
+
+    def clear(self) -> None:
+        self._challenges.clear()
+        self._blocked_until = 0.0
+
+    def _prune(self, now: float, window: float) -> None:
+        while self._challenges and now - self._challenges[0] > window:
+            self._challenges.popleft()
+
+
+def _breaker(settings: Dict) -> Dict:
+    return {
+        "threshold": settings["threshold"],
+        "window": settings["window"],
+        "cooldown": settings["cooldown"],
+    }
+
+
+async def _get(session: aiohttp.ClientSession, url: str, gate: ChallengeGate, settings: Dict) -> Tuple[int, object]:
+    """One GET. Returns (200, decoded json) or (501, challenge html)."""
+    try:
+        async with session.get(url) as r:
+            if r.status == 200:
+                try:
+                    return 200, await r.json()
+                except (aiohttp.ContentTypeError, ValueError) as e:
+                    raise DerpiBusy("derpibooru answered 200 with a non-json body") from e
+            if r.status == 500:
+                gate.record_block(time.time(), cooldown=settings["block_cooldown"])
+                raise DerpiCold(gate.cold_remaining(time.time()))
+            if r.status == 501:
+                return 501, await r.text()
+            raise DerpiError("derpibooru returned HTTP {}".format(r.status))
+    except aiohttp.ClientError as e:
+        raise DerpiError("request failed: {}".format(e)) from e
+    except asyncio.TimeoutError as e:
+        raise DerpiError("request timed out") from e
+
+
+async def fetch_json(session: aiohttp.ClientSession, url: str, gate: ChallengeGate, settings: Dict) -> Dict:
+    """Fetch a Derpibooru API url, solving the interstitial once if we hit it.
+
+    Callers hold the cog lock, which is what makes the three-request ceiling global
+    rather than per invocation.
+    """
+    remaining = gate.cold_remaining(time.time())
+    if remaining > 0:
+        raise DerpiCold(remaining)
+
+    status, payload = await _get(session, url, gate, settings)
+    if status == 200:
+        return payload
+
+    tripped = gate.record_challenge(time.time(), **_breaker(settings))
+    if not settings.get("autosolve", True):
+        raise DerpiBusy("challenged, and autosolve is off")
+    if tripped:
+        raise DerpiCold(gate.cold_remaining(time.time()))
+
+    fields = parse_challenge(payload)
+    if fields is None:
+        raise DerpiBusy("derpibooru served a challenge page we don't recognise")
+
+    try:
+        # The 302 Location comes back with a literal "&amp;", so following it would
+        # request a parameter named "amp;per_page".
+        async with session.post(CHALLENGE_URL, data=fields, allow_redirects=False) as r:
+            if r.status != 302:
+                raise DerpiBusy("challenge submission returned HTTP {}".format(r.status))
+    except aiohttp.ClientError as e:
+        raise DerpiError("challenge submission failed: {}".format(e)) from e
+    except asyncio.TimeoutError as e:
+        raise DerpiError("challenge submission timed out") from e
+
+    await asyncio.sleep(SOLVE_RETRY_WAIT)
+
+    status, payload = await _get(session, url, gate, settings)
+    if status == 200:
+        return payload
+    raise DerpiBusy("derpibooru is still challenging after a solve")

--- a/pony/info.json
+++ b/pony/info.json
@@ -4,16 +4,11 @@
     "somethingux",
     "Alzarath"
   ],
-  "bot_version": [
-    3,
-    5,
-    0
-  ],
+  "min_bot_version": "3.5.0",
   "description": "Search derpibooru for images of ponies! Fully customizable filter list!",
   "hidden": false,
   "install_msg": "Thank you for using this cog! Please make sure to setup the filters to your liking using '[p]ponyfilter'.",
   "requirements": [
-    "urllib3",
     "aiohttp"
   ],
   "short": "Search derpibooru for images of ponies!",

--- a/pony/pony.py
+++ b/pony/pony.py
@@ -1,24 +1,42 @@
 import discord
 from redbot.core.utils.chat_formatting import *
 from redbot.core import Config, checks, commands
+from redbot.core.commands import BadArgument
+from redbot.core.utils.chat_formatting import humanize_timedelta
 from urllib import parse
 from typing import Literal, Optional, Union
 import aiohttp
+import logging
 import os
-import traceback
 import json
 import asyncio
 import time
 
+from .derpi import ChallengeGate, DerpiBusy, DerpiCold, DerpiError, fetch_json, make_ssl_context
+
+log = logging.getLogger("red.brandons209.pony")
+
+# Derpibooru's own block lasts 15 minutes, and requests during it restart the timer,
+# so a shorter cold period only keeps us blocked longer.
+MIN_BLOCK_COOLDOWN = 900
+
 
 class Pony(commands.Cog):
-    __version__ = "5.0.0"
+    __version__ = "5.1.0"
 
     def __init__(self, bot):
         super().__init__()
         self.bot = bot
         self.config = Config.get_conf(self, identifier=7384662719)
-        default_global = {"maxfilters": 50}
+        default_global = {
+            "maxfilters": 50,
+            "challenge_autosolve": True,
+            "challenge_threshold": 3,
+            "challenge_window": 900,
+            "challenge_cooldown": 900,
+            "challenge_block_cooldown": 960,
+            "challenge_blocked_until": 0.0,
+        }
         self.default_guild = {
             "filters": ["-meme", "safe", "-spoiler:*", "-vulgar"],
             "verbose": False,
@@ -31,19 +49,31 @@ class Pony(commands.Cog):
         self.config.register_global(**default_global)
         self.config.register_channel(**default_channel)
 
+        # Clearance is keyed to our IP, so one gate and one lock cover every guild.
+        # The lock is also what holds the three-request-per-fetch ceiling globally.
+        self.gate = ChallengeGate()
+        self.derpi_lock = asyncio.Lock()
+        self.session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=15),
+            headers={"User-Agent": "Booru-Bot"},
+            connector=aiohttp.TCPConnector(ssl=make_ssl_context()),
+        )
+
         self.task = asyncio.create_task(self.init())
 
-    def cog_unload(self):
+    async def cog_unload(self):
         if self.task:
             self.task.cancel()
+        await self.session.close()
 
     async def init(self):
         """
-        Setup cooldown cache
+        Setup cooldown cache and restore any cold period we were in before a reload
         """
         await self.bot.wait_until_ready()
         for guild in self.bot.guilds:
             self.cooldowns[guild.id] = {}
+        self.gate.restore(await self.config.challenge_blocked_until())
 
     @commands.hybrid_command()
     @commands.guild_only()
@@ -277,6 +307,121 @@ class Pony(commands.Cog):
         await self.config.maxfilters.set(new_max_filters)
         await ctx.send("Maximum filters allowed per server for pony set to '{}'.".format(new_max_filters))
 
+    @ponyset.group(name="challenge")
+    @checks.is_owner()
+    async def ponyset_challenge(self, ctx):
+        """Manage how the cog handles Derpibooru's anti-bot challenge
+
+        Derpibooru serves a challenge page when the whole site is under load, not
+        because of anything this bot did. The cog solves it automatically. These
+        settings control when it stops solving and backs off instead.
+
+        Settings are global: the clearance is tied to the bot's IP, not to a guild.
+        """
+        pass
+
+    @ponyset_challenge.command(name="threshold")
+    async def _challenge_threshold(self, ctx, count: int):
+        """Challenged requests allowed in the window before the cog backs off"""
+        if count < 1:
+            return await ctx.send("Threshold must be at least 1.")
+        await self.config.challenge_threshold.set(count)
+        window = await self.config.challenge_window()
+        await ctx.send(
+            f"Backing off after more than **{count}** challenged requests in {humanize_timedelta(seconds=window)}."
+        )
+
+    @ponyset_challenge.command(name="window")
+    async def _challenge_window(self, ctx, *, duration: str):
+        """Rolling window the challenge threshold is counted over
+
+        Example: [p]ponyset challenge window 15m"""
+        seconds = self.parse_duration(duration, minimum=60, maximum=86400)
+        await self.config.challenge_window.set(seconds)
+        threshold = await self.config.challenge_threshold()
+        await ctx.send(
+            f"Counting challenged requests over **{humanize_timedelta(seconds=seconds)}** (threshold {threshold})."
+        )
+
+    @ponyset_challenge.command(name="cooldown")
+    async def _challenge_cooldown(self, ctx, *, duration: str):
+        """How long to stop talking to Derpibooru once the threshold is exceeded"""
+        seconds = self.parse_duration(duration, minimum=60, maximum=86400)
+        await self.config.challenge_cooldown.set(seconds)
+        await ctx.send(f"Backoff after too many challenges set to **{humanize_timedelta(seconds=seconds)}**.")
+
+    @ponyset_challenge.command(name="blockcooldown")
+    async def _challenge_block_cooldown(self, ctx, *, duration: str):
+        """How long to go silent after Derpibooru hard-blocks us (HTTP 500)
+
+        Cannot be set below 15 minutes. That is how long Derpibooru's block lasts,
+        and any request sent during it restarts the timer, so a shorter value would
+        only keep the bot blocked for longer."""
+        seconds = self.parse_duration(duration, minimum=60, maximum=86400)
+        clamped = max(seconds, MIN_BLOCK_COOLDOWN)
+        await self.config.challenge_block_cooldown.set(clamped)
+        msg = f"Backoff after a hard block set to **{humanize_timedelta(seconds=clamped)}**."
+        if clamped != seconds:
+            msg += f"\nRaised from {humanize_timedelta(seconds=seconds)}: Derpibooru's own block lasts 15 minutes."
+        await ctx.send(msg)
+
+    @ponyset_challenge.command(name="autosolve")
+    async def _challenge_autosolve(self, ctx, toggle: bool):
+        """Toggle solving the challenge automatically
+
+        With this off, a challenged request just tells the user the site is busy."""
+        await self.config.challenge_autosolve.set(toggle)
+        if toggle:
+            await ctx.send("Auto-solving the Derpibooru challenge is now enabled.")
+        else:
+            await ctx.send("Auto-solving is now disabled. Challenged requests will report the site as busy.")
+
+    @ponyset_challenge.command(name="status")
+    async def _challenge_status(self, ctx):
+        """Show the current challenge and backoff state"""
+        settings = await self.challenge_settings()
+        now = time.time()
+        remaining = self.gate.cold_remaining(now)
+        recent = self.gate.challenges_in_window(now, settings["window"])
+
+        if remaining > 0:
+            state = f"**Backing off**, {humanize_timedelta(seconds=max(1, int(remaining)))} remaining"
+        else:
+            state = "**Ready**"
+
+        msg = (
+            f"{state}\n"
+            f"Challenged requests in the last {humanize_timedelta(seconds=settings['window'])}: "
+            f"**{recent}** (threshold {settings['threshold']})\n"
+            f"Auto-solve: **{'on' if settings['autosolve'] else 'off'}**\n"
+            f"Backoff after too many challenges: **{humanize_timedelta(seconds=settings['cooldown'])}**\n"
+            f"Backoff after a hard block: **{humanize_timedelta(seconds=settings['block_cooldown'])}**"
+        )
+        await ctx.send(msg)
+
+    @ponyset_challenge.command(name="clear")
+    async def _challenge_clear(self, ctx):
+        """Clear the current backoff and the challenge history
+
+        Only use this if you know the site has recovered. Requests sent while
+        Derpibooru still has us blocked restart its 15 minute timer."""
+        self.gate.clear()
+        await self.config.challenge_blocked_until.set(0.0)
+        await ctx.send("Backoff cleared.")
+
+    @staticmethod
+    def parse_duration(duration: str, *, minimum: int, maximum: int) -> int:
+        delta = commands.parse_timedelta(duration)
+        if delta is None:
+            raise BadArgument(f"`{duration}` is not a valid duration. Try something like `15m` or `1h30m`.")
+        seconds = int(delta.total_seconds())
+        if seconds < minimum or seconds > maximum:
+            raise BadArgument(
+                f"Duration must be between {humanize_timedelta(seconds=minimum)} "
+                f"and {humanize_timedelta(seconds=maximum)}."
+            )
+        return seconds
+
     @ponyset.command(name="import")
     @checks.is_owner()
     async def _import_ponyset(self, ctx, path_to_import):
@@ -333,18 +478,43 @@ class Pony(commands.Cog):
         except json.decoder.JSONDecodeError:
             await ctx.send("Invalid or malformed json files.")
 
+    async def challenge_settings(self):
+        conf = self.config
+        return {
+            "autosolve": await conf.challenge_autosolve(),
+            "threshold": await conf.challenge_threshold(),
+            "window": await conf.challenge_window(),
+            "cooldown": await conf.challenge_cooldown(),
+            "block_cooldown": await conf.challenge_block_cooldown(),
+        }
+
+    async def derpi_fetch(self, url):
+        """Serialize every Derpibooru request and persist any cold period it earns."""
+        settings = await self.challenge_settings()
+        async with self.derpi_lock:
+            before = self.gate.blocked_until
+            try:
+                return await fetch_json(self.session, url, self.gate, settings)
+            finally:
+                # Persisted so a reload mid-block doesn't resume hammering. Only on a
+                # change, which keeps the write off the hot path.
+                if self.gate.blocked_until != before:
+                    await self.config.challenge_blocked_until.set(self.gate.blocked_until)
+                    log.warning("derpibooru backoff engaged for %.0fs", self.gate.cold_remaining(time.time()))
+
     async def fetch_image(self, ctx, randomize: bool = False, tags: str = "", mascot=False):
         guild = ctx.guild
         channel = ctx.channel
-        # check cooldown
-        if self.cooldowns[guild.id].get(ctx.author.id, 0) > time.time():
-            left = self.cooldowns[guild.id].get(ctx.author.id, 0) - time.time()
+        # setdefault, not [], because init() only seeds guilds present at startup
+        cooldowns = self.cooldowns.setdefault(guild.id, {})
+        if cooldowns.get(ctx.author.id, 0) > time.time():
+            left = cooldowns.get(ctx.author.id, 0) - time.time()
             return await ctx.send(
                 "Sorry, that command is on cooldown for {:.0f} seconds.".format(left), delete_after=left
             )
         else:
             cooldown = await self.config.guild(guild).cooldown()
-            self.cooldowns[guild.id][ctx.author.id] = time.time() + cooldown
+            cooldowns[ctx.author.id] = time.time() + cooldown
 
         tags = [t for t in tags.split(",") if t != ""]
         filters = await self.config.guild(guild).filters()
@@ -353,7 +523,6 @@ class Pony(commands.Cog):
         verbose = await self.config.guild(guild).verbose()
         display_artist = await self.config.guild(guild).display_artist()
 
-        # Initialize variables
         artist = "unknown artist"
         artists = ""
         artistList = []
@@ -368,9 +537,9 @@ class Pony(commands.Cog):
         search = "https://derpibooru.org/api/v1/json/search/images?q="
         tagSearch = ""
 
-        # Assign tags to URL
         if tags:
-            # parentheses resolves user's search before filters so that OR operator doesnt break search
+            # Parenthesised so the user's search resolves before the filters, otherwise
+            # an OR in their query swallows them.
             tagSearch += "({})".format(", ".join(tags)).strip().strip(",")
         if not mascot:
             if filters != [] and tags:
@@ -381,7 +550,8 @@ class Pony(commands.Cog):
         if search[-1] == "=":
             search += "safe"
 
-        # Randomize results and apply Derpibooru's "Everything" filter
+        # filter_id=56027 is Derpibooru's "Everything" filter; our own tags do the
+        # gating, so the site-side filter must not narrow the pool first.
         if randomize:
             if not tags and not filters:
                 search = "https://derpibooru.org/api/v1/json/search/images?q=safe&sf=random&filter_id=56027&per_page=1"
@@ -390,36 +560,38 @@ class Pony(commands.Cog):
         else:
             search += "&filter_id=56027&per_page=1"
 
-        # Inform users about image retrieving
+        # Also covers the 5s pause when a challenge has to be solved.
         message = await ctx.send("Fetching pony image...")
 
-        # Fetch the image or display an error
         try:
-            async with aiohttp.ClientSession(loop=ctx.bot.loop) as session:
-                async with session.get(search, headers={"User-Agent": "Booru-Bot"}) as r:
-                    website = await r.json()
+            website = await self.derpi_fetch(search)
+        except DerpiCold as e:
+            left = humanize_timedelta(seconds=max(1, int(e.remaining)))
+            return await message.edit(content=f"Derpibooru is under heavy load. Try again in {left}.")
+        except DerpiBusy as e:
+            log.info("derpibooru busy: %s", e)
+            return await message.edit(content="Derpibooru is under load right now. Try again in a moment.")
+        except DerpiError as e:
+            log.error("derpibooru request failed: %s", e)
+            return await message.edit(content="Error! Contact bot owner.")
+
+        try:
             if website["total"] > 0:
                 website = website["images"][0]
                 imageId = website["id"]
                 imageURL = website["representations"]["full"]
             else:
                 return await message.edit(content="Your search terms gave no results.")
-        except Exception as e:
-            traceback.print_exc()
+        except (KeyError, IndexError, TypeError) as e:
+            log.error("unexpected derpibooru response shape: %s", e)
             return await message.edit(content="Error! Contact bot owner.")
 
-        # If verbose mode is enabled, create an embed and fill it with information
         if verbose:
-            # Sets the embed title
             embedTitle = "Derpibooru Image #{}".format(imageId)
-
-            # Sets the URL to be linked
             embedLink = "https://derpibooru.org/{}".format(imageId)
-
-            # Populates the tag list
             tagList = website["tags"]
 
-            # Checks for the rating and sets an appropriate color
+            # Pops the rating out of tagList so it isn't repeated in the tag field.
             for i in range(0, len(tagList)):
                 if tagList[i] == "safe":
                     ratingColor = "00FF00"
@@ -438,7 +610,6 @@ class Pony(commands.Cog):
                     ratingWord = tagList.pop(i)
                     break
 
-            # Grabs the artist(s)
             toRemove = []
             for tag in tagList:
                 if "artist:" in tag:
@@ -447,17 +618,13 @@ class Pony(commands.Cog):
 
             tagList = list(set(tagList) - set(toRemove))
 
-            # Determine if there are multiple artists
             if len(artistList) == 1:
                 artist = artistList[0]
             elif len(artistList) > 1:
                 artists = ", ".join(artistList)
                 artist = ""
 
-            # Initialize verbose embed
             output = discord.Embed(title=embedTitle, url=embedLink, colour=discord.Colour(value=int(ratingColor, 16)))
-
-            # Sets the thumbnail and adds the rating and tag fields to the embed
             output.add_field(name="Rating", value=ratingWord)
             if artist:
                 output.add_field(name="Artist", value=artist)
@@ -467,10 +634,8 @@ class Pony(commands.Cog):
             output.add_field(name="Search url", value=search)
             output.set_thumbnail(url=imageURL)
         else:
-            # Sets the link to the image URL if verbose mode is not enabled
             output = imageURL
 
-        # Edits the pending message with the results
         if verbose:
             return await message.edit(content="Image found.", embed=output)
         elif display_artist:
@@ -478,7 +643,6 @@ class Pony(commands.Cog):
                 if "artist:" in tag:
                     artistList.append(tag[7:])
 
-            # Determine if there are multiple artists
             if len(artistList) == 1:
                 artist = artistList[0]
             elif len(artistList) > 1:


### PR DESCRIPTION
Two separate things were breaking [p]pony, and the old bare `except Exception` reported both as "Error! Contact bot owner."

Cloudflare fingerprints the TLS ClientHello. aiohttp's default omits the ALPN and post_handshake_auth extensions, which draws a 403 whatever the User-Agent, while curl and python's own http.client both get through from the same IP. make_ssl_context sends what http.client sends.

Past that, derpibooru serves its own 501 interstitial while shedding load: a form with two hidden fields, no javascript. POSTing them back clears it, and the clearance is keyed to our IP with no cookie, so one gate covers every guild.

Requests sent during a block restart its 15 minute timer, so the fetch spends at most three requests (GET, POST /challenge, GET) and solves at most once; a retry that is challenged again gives up rather than looping. A 500 goes cold for 16 minutes, persisted so a reload mid-block doesn't resume hammering. More than three challenged requests in 15 minutes trips a breaker, tunable via [p]ponyset challenge along with a kill switch, a status readout and a manual clear. blockcooldown clamps to 15 minutes since anything shorter only extends the block.

Also in the same path:
- fetch_image crashed with KeyError in any guild joined after startup, since init() only seeded guilds present at boot
- one long-lived session with a timeout, closed in an async cog_unload, replacing the per-command session built with the removed `loop=` kwarg
- red.brandons209.pony logger in place of traceback.print_exc()
- info.json: legacy bot_version array to min_bot_version, drop the unused urllib3

ChallengeGate and parse_challenge take no discord or redbot imports and are driven by a caller-supplied now, so both are tested standalone.